### PR TITLE
feat(keyword): support regexp （keyword插件增加正则表达式支持)

### DIFF
--- a/keyword/main.py
+++ b/keyword/main.py
@@ -1,4 +1,5 @@
 import contextlib
+import re
 
 from typing import Optional, List
 
@@ -20,6 +21,7 @@ class KeywordTask:
     key: str
     msg: str
     include: bool
+    regexp: bool
     exact: bool
     case: bool
     ignore_forward: bool
@@ -29,7 +31,7 @@ class KeywordTask:
     restrict: int
     delay_delete: int
 
-    def __init__(self, task_id: Optional[int] = None, cid: int = 0, key: str = "", msg: str = "", include: bool = True,
+    def __init__(self, task_id: Optional[int] = None, cid: int = 0, key: str = "", msg: str = "", include: bool = True, regexp: bool = False,
                  exact: bool = False, case: bool = False, ignore_forward: bool = False,
                  reply: bool = True, delete: bool = False, ban: int = 0, restrict: int = 0, delay_delete: int = 0):
         self.task_id = task_id
@@ -37,6 +39,7 @@ class KeywordTask:
         self.key = key
         self.msg = msg
         self.include = include
+        self.regexp = regexp
         self.exact = exact
         self.case = case
         self.ignore_forward = ignore_forward
@@ -47,7 +50,7 @@ class KeywordTask:
         self.delay_delete = delay_delete
 
     def export(self):
-        return {"task_id": self.task_id, "cid": self.cid, "key": self.key, "msg": self.msg, "include": self.include,
+        return {"task_id": self.task_id, "cid": self.cid, "key": self.key, "msg": self.msg, "include": self.include, "regexp": self.regexp,
                 "exact": self.exact, "case": self.case, "ignore_forward": self.ignore_forward, "reply": self.reply,
                 "delete": self.delete, "ban": self.ban, "restrict": self.restrict, "delay_delete": self.delay_delete}
 
@@ -75,13 +78,16 @@ class KeywordTask:
             return False
         text = message.text or message.caption
         key = self.key
-        if not self.case:
-            text = text.lower()
-            key = key.lower()
-        if self.include and text.find(key) != -1:
-            return True
-        if self.exact and text == key:
-            return True
+        if self.regexp:
+            return re.search(key,text)
+        else:
+            if not self.case:
+                text = text.lower()
+                key = key.lower()
+            if self.include and text.find(key) != -1:
+                return True
+            if self.exact and text == key:
+                return True
         return False
 
     @staticmethod
@@ -151,6 +157,8 @@ class KeywordTask:
                     self.include = True
                 elif i.startswith("exact"):
                     self.exact = True
+                elif i.startswith("regexp"):
+                    self.regexp = True
                 elif i.startswith("case"):
                     self.case = True
                 elif i.startswith("ignore_forward"):


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

无

## 插件名称 / Name

```
keyword
```

## 更改检查表 / Change Checklist
  
- [ ] 有插件版本号更新
- [ ] 有多语言支持
  - [ ] CN
  - [ ] EN
- [ ] 会触发频率限制 Will trigger a rate limit?
  - [ ] 如果会, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 添加了新的依赖包 New package added

## 说明 / Note
keyword 目前只支持纯关键字部分或全部匹配，有一些复杂的关键字场景设置起来比较麻烦。因此本人做了一点小修改，加上了 regexp 模式，关键字可以使用任何 python 支持的正则表达式，可以适应更多场景。本地已经测试通过，特此申请合并，请审核。