### PR TITLE
shift 支持所有对话类型并且支持设置备份选项

### DIFF
--- a/shift/main.py
+++ b/shift/main.py
@@ -17,7 +17,7 @@ from pagermaid.utils import lang
 
 WHITELIST = [-1001441461877]
 AVAILABLE_OPTIONS = {"silent", "text", "all", "photo", "document", "video"}
-options=[]
+
 
 def try_cast_or_fallback(val: Any, t: type) -> Any:
     try:
@@ -28,7 +28,7 @@ def try_cast_or_fallback(val: Any, t: type) -> Any:
 
 def check_chat_available(chat: Chat):
     assert (
-        chat.type in [ChatType.CHANNEL, ChatType.GROUP,ChatType.SUPERGROUP,ChatType.BOT,ChatType.PRIVATE]
+        chat.type in [ChatType.CHANNEL, ChatType.GROUP]
         and not chat.has_protected_content
     )
 
@@ -44,7 +44,6 @@ def check_chat_available(chat: Chat):
     "silent: 禁用通知, text: 文字, all: 全部訊息都傳, photo: 圖片, document: 檔案, video: 影片",
 )
 async def shift_set(client: Client, message: Message):
-    global options
     if not message.parameter:
         await message.edit(f"{lang('error_prefix')}{lang('arg_error')}")
         return
@@ -130,11 +129,7 @@ async def shift_set(client: Client, message: Message):
             return await message.edit("出错了呜呜呜 ~ 此对话位于白名单中。")
         # 开始遍历消息
         await message.edit(f"开始备份频道 {source.id} 到 {target.id} 。")
-
-        # 如果有把get_chat_history方法merge進去就可以實現從舊訊息到新訊息,https://github.com/pyrogram/pyrogram/pull/1046
-        # async for msg in client.get_chat_history(source.id,reverse=True):  
-
-        async for msg in client.search_messages(source.id):  # type: ignore    
+        async for msg in client.search_messages(source.id):  # type: ignore
             await sleep(uniform(0.5, 1.0))
             await loosely_forward(
                 message,
@@ -178,7 +173,8 @@ async def shift_channel_message(message: Message):
     source = message.chat.id
 
     # 找訊息類型video、document...
-    media_type = message.media.value if message.media else "text"
+    media_type = message.media.name.lower() if message.media else "text"
+
     target = d.get(f"shift.{source}")
     if not target:
         return
@@ -208,22 +204,8 @@ async def loosely_forward(
     chat_id: int,
     disable_notification: bool = False,
 ):
-    # 找訊息類型video、document...
-    media_type = message.media.value if message.media else "text"
     try:
-        if (not options) or "all" in options:
-            await message.forward(
-                chat_id,
-                disable_notification=disable_notification,
-            )
-        elif media_type in options:
-            await message.forward(
-                chat_id,
-                disable_notification=disable_notification,
-            )
-        else:
-            logs.debug("skip message type: %s", media_type)
-        # await message.forward(chat_id, disable_notification=disable_notification)
+        await message.forward(chat_id, disable_notification=disable_notification)
     except FloodWait as ex:
         min: int = ex.value  # type: ignore
         delay = min + uniform(0.5, 1.0)

--- a/shift/main.py
+++ b/shift/main.py
@@ -28,8 +28,8 @@ def try_cast_or_fallback(val: Any, t: type) -> Any:
 
 def check_chat_available(chat: Chat):
     assert (
-        chat.type in [ChatType.CHANNEL, ChatType.GROUP,ChatType.SUPERGROUP,ChatType.BOT,ChatType.PRIVATE]
-        and not chat.has_protected_content
+            chat.type in [ChatType.CHANNEL, ChatType.GROUP, ChatType.SUPERGROUP, ChatType.BOT, ChatType.PRIVATE]
+            and not chat.has_protected_content
     )
 
 
@@ -37,11 +37,11 @@ def check_chat_available(chat: Chat):
     command="shift",
     description="开启转发频道新消息功能",
     parameters="set [from channel] [to channel] (silent) 自动转发频道新消息（可以使用频道用户名或者 id）\n"
-    "del [from channel] 删除转发\n"
-    "backup [from channel] [to channel] (silent) 备份频道（可以使用频道用户名或者 id）\n"
-    "list 顯示目前轉發的頻道\n\n"
-    "选项说明：\n"
-    "silent: 禁用通知, text: 文字, all: 全部訊息都傳, photo: 圖片, document: 檔案, video: 影片",
+               "del [from channel] 删除转发\n"
+               "backup [from channel] [to channel] (silent) 备份频道（可以使用频道用户名或者 id）\n"
+               "list 顯示目前轉發的頻道\n\n"
+               "选项说明：\n"
+               "silent: 禁用通知, text: 文字, all: 全部訊息都傳, photo: 圖片, document: 檔案, video: 影片",
 )
 async def shift_set(client: Client, message: Message):
     if not message.parameter:
@@ -203,11 +203,11 @@ async def shift_channel_message(message: Message):
 
 
 async def loosely_forward(
-    notifier: Message,
-    message: Message,
-    chat_id: int,
-    options: Union[List[str], Set[str]],
-    disable_notification: bool = False,
+        notifier: Message,
+        message: Message,
+        chat_id: int,
+        options: Union[List[str], Set[str]],
+        disable_notification: bool = False,
 ):
     # 找訊息類型video、document...
     media_type = message.media.value if message.media else "text"

--- a/shift/main.py
+++ b/shift/main.py
@@ -41,7 +41,7 @@ def check_chat_available(chat: Chat):
     "backup [from channel] [to channel] (silent) 备份频道（可以使用频道用户名或者 id）\n"
     "list 顯示目前轉發的頻道\n\n"
     "选项说明：\n"
-    "silent: 禁用通知, none: 文字, all: 全部訊息都傳, photo: 圖片, document: 檔案, video: 影片",
+    "silent: 禁用通知, text: 文字, all: 全部訊息都傳, photo: 圖片, document: 檔案, video: 影片",
 )
 async def shift_set(client: Client, message: Message):
     if not message.parameter:


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

#176 

## 插件名称 / Name

```
shift
```

## 更改检查表 / Change Checklist
  
- [ ] 有插件版本号更新
- [ ] 有多语言支持
  - [ ] CN
  - [ ] EN
- [ ] 会触发频率限制 Will trigger a rate limit?
  - [ ] 如果会, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 添加了新的依赖包 New package added

## 说明 / Note
加入全部頻道類型(頻道、群組、超級群組、機器人、私人)
,shift backup 可以篩選檔案類型(text, photo, document, video...)
另外有找到別人寫好的 get_chat_history 的 reverse 選項，如果可以合併進pyrogram就能實現從舊訊息到新訊息轉傳
https://github.com/pyrogram/pyrogram/pull/1046
https://github.com/Dineshkarthik/pyrogram/blob/6966455d4a4d3981f1771271a60cbb3b57c2edbe/pyrogram/methods/messages/get_chat_history.py