### PR TITLE
cleanda 支持查找与已注销账号的会话

### DIFF
--- a/cleanda/DES.md
+++ b/cleanda/DES.md
@@ -1,0 +1,1 @@
+cleanda 删除会话列表中所有Deleted Account

--- a/cleanda/DES.md
+++ b/cleanda/DES.md
@@ -1,1 +1,1 @@
-cleanda 删除会话列表中所有Deleted Account
+cleanda 查找会话列表中所有Deleted Account

--- a/cleanda/main.py
+++ b/cleanda/main.py
@@ -1,0 +1,24 @@
+from pagermaid.dependence import add_delete_message_job
+from pagermaid.enums import Message
+from pagermaid.listener import listener
+from pagermaid.services import bot
+from pyrogram import Client, enums
+
+
+@listener(
+    command="cleanda", description="查找与已注销账号的会话"
+)
+async def clean_member(client: Client, message: Message):
+    await message.edit("正在查找与已注销账号的会话，请稍等...")
+    deleted = []
+    async for dialog in client.get_dialogs():
+        chat = dialog.chat
+        if chat.type == enums.ChatType.PRIVATE:
+            user = await client.get_users(chat.id)
+            if getattr(user, "is_deleted", False):
+                deleted.append(chat.id)
+    await message.edit(
+        f"共找到{len(deleted)}个与已注销账号的会话，请手动检查并删除\n\n"
+        + "".join([f"[{uid}](tg://openmessage?user_id={uid})\n" for uid in deleted]),
+        parse_mode=enums.ParseMode.MARKDOWN
+    )

--- a/cleanda/main.py
+++ b/cleanda/main.py
@@ -1,7 +1,5 @@
-from pagermaid.dependence import add_delete_message_job
 from pagermaid.enums import Message
 from pagermaid.listener import listener
-from pagermaid.services import bot
 from pyrogram import Client, enums
 
 


### PR DESCRIPTION
## 插件名称 / Name
cleanda

## 更改检查表 / Change Checklist
  
- [ ] 有插件版本号更新
- [ ] 有多语言支持
  - [ ] CN
  - [ ] EN
- [ ] 会触发频率限制 Will trigger a rate limit?
  - [ ] 如果会, 是否有对应的措施? If yes, do your code reflect this sign?
- [ ] 添加了新的依赖包 New package added

## 说明 / Note
支持查找与已注销账号（Deleted Account）的私聊会话，提供会话链接以供查看。
设想的是由程序自动删除会话，但查阅文档后似乎没有找到相关功能。如有支持删除对话，欢迎改进

## Summary by Sourcery

Add a `cleanda` command to scan private chats for deleted accounts and list them with clickable links.

New Features:
- Introduce `cleanda` listener to identify and list private dialogs with deleted accounts.

Documentation:
- Add DES.md to describe removal of conversations with Deleted Accounts.